### PR TITLE
Correct vowel check

### DIFF
--- a/bulstem.py
+++ b/bulstem.py
@@ -71,7 +71,7 @@ def stem(word):
 		return word
 
 	'If no bulgarian vowel - no valid word'
-	if not re_bg_vowels.match(word):
+	if not re_bg_vowels.search(word):
 		return word
 
 	'Convert to lower case in order to compare it easy'

--- a/bulstem.py
+++ b/bulstem.py
@@ -1,17 +1,17 @@
 #!/usr/local/bin/python
 # -*- coding: utf-8 -*-
 '''
-Implementation author: Peio Popov <peio@peio.org> 
+Implementation author: Peio Popov <peio@peio.org>
 Algorithm author: Preslav Nakov <nakov@cs.berkeley.edu>, UC Berkeley
 Paper: BulStem: Inflectional Stemmer For Bulgarian http://people.ischool.berkeley.edu/~nakov/bulstem/
 
 Description: Stems a text file
 
-Example usage: 
+Example usage:
 > from nltk.tokenize import word_tokenize, sent_tokenize, wordpunct_tokenize
 > from bulstem import stem, MIN_WORD_LEN
 
-> text = u""" "Името на Мирослава Тодорова ми стана известно, когато към мен се обърнаха жертвите на престъпността", заяви по повод дисциплинарното уволнение на съдията вицепремиерът и министър на вътрешните работи Цветан Цветанов. В сутрешния блок на БНТ Цветанов наблегна на проблемите в съдебната система, като започна разговора с думите "ВСС е независима съдебна институция, която не бих искал да коментирам" """ 
+> text = u""" "Името на Мирослава Тодорова ми стана известно, когато към мен се обърнаха жертвите на престъпността", заяви по повод дисциплинарното уволнение на съдията вицепремиерът и министър на вътрешните работи Цветан Цветанов. В сутрешния блок на БНТ Цветанов наблегна на проблемите в съдебната система, като започна разговора с думите "ВСС е независима съдебна институция, която не бих искал да коментирам" """
 
 > for word in wordpunct_tokenize(text):
 	if len(word) >= MIN_WORD_LEN:
@@ -31,24 +31,24 @@ def fetchTheRules(RULES_FILE, MIN_RULE_FREQ):
 	'Read the rules and load them into dictionary'
 	import codecs
 
-	re_empty_line = re.compile('^\s*$') 
+	re_empty_line = re.compile('^\s*$')
 	re_rule_line = re.compile(u"([а-я-]+) ==> ([a-я-]+) (\d+)", re.U)
 	StemmingRules = {}
 
 	for rule in codecs.open(RULES_FILE, 'r', 'utf-8').readlines():
 		if re_empty_line.match(rule):
 			continue
-			
+
 		'Break the rule line in three parts match(1) - reduce(2) - probability(3)'
 		rule_parts = re_rule_line.match(rule)
-		
+
 		if rule_parts != None:
 			if rule_parts.group(3) > MIN_RULE_FREQ:
-				
+
 				'Build a dictionary indexed by the lenght of the match'
 				match_len = len(rule_parts.group(1))
 				try:
-					StemmingRules[match_len][rule_parts.group(1)] = rule_parts.group(2)					
+					StemmingRules[match_len][rule_parts.group(1)] = rule_parts.group(2)
 				except KeyError:
 					StemmingRules[match_len] = {}
 					StemmingRules[match_len][rule_parts.group(1)] = rule_parts.group(2)
@@ -58,7 +58,7 @@ def fetchTheRules(RULES_FILE, MIN_RULE_FREQ):
 			continue
 
 	'Using a pickle would be faster'
-	cPickle.dump(StemmingRules, open('rules/StemmingRules-MinFreq-'+str(MIN_RULE_FREQ)+'.pickle', 'wb')) 
+	cPickle.dump(StemmingRules, open('rules/StemmingRules-MinFreq-'+str(MIN_RULE_FREQ)+'.pickle', 'wb'))
 
 	return StemmingRules
 
@@ -82,19 +82,19 @@ def stem(word):
 	for _ in word:
 		'Reduce the word from the begining towards the end'
 		stem = word[c:wordLen]
-	
+
 		'Calculate the reminding symbols for better search'
 		word_reminder = wordLen - c
-		
+
 		'Check if there is a stem matching the reminder of the word'
-		if StemmingRules[word_reminder].has_key(stem):
+		if StemmingRules.has_key(word_reminder) and StemmingRules[word_reminder].has_key(stem):
 			'Return stemmed word'
 			return word[:c]+StemmingRules[word_reminder][stem]
 			break
 		else:
 			c += 1
 
-	'Always return something'		
+	'Always return something'
 	return word
 
 'Try to reload the rules or build them from the text files'


### PR DESCRIPTION
Python's `re.match` method only checks the beginning of the string as opposed to the `re.search` method which check the entire word ([docs](https://docs.python.org/2.7/library/re.html#search-vs-match)).
In addition, place a safeguard against a `KeyError`